### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Aura",
-	"minAppVersion": "1.6.0",
+	"minAppVersion": "1.13.0",
 	"author": "Ashwin Jadhav",
 	"authorUrl": "https://github.com/ashwinjadhav818/",
 	"version": "2.3.5"

--- a/src/features/callouts.scss
+++ b/src/features/callouts.scss
@@ -12,7 +12,7 @@
 }
 .aura-callouts.aura-callouts-vanilla .callout .callout-title,
 .aura-callouts.aura-callouts-vanilla .callout .callout-content {
-	border-left: var(--size-2-3) solid rgb(var(--callout-color));
+	border-left: var(--size-2-3) solid var(--callout-color);
 }
 .aura-callouts.aura-callouts-sleek .callout:not(.is-collapsible) {
 	padding: 0px;
@@ -37,7 +37,7 @@
 	font-weight: normal;
 }
 .aura-callouts.aura-callouts-sleek .callout:not(.is-collapsible) {
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	border-width: 1px;
 	border-radius: var(--callout-radius);
 	background-color: rgba(var(--cpt-mantle), 0.4);
@@ -45,7 +45,7 @@
 .aura-callouts.aura-callouts-sleek .callout-content {
 	padding: var(--callout-title-padding) var(--callout-title-padding)
 		var(--callout-title-padding) calc(var(--callout-title-padding) * 1.5);
-	border-top: 1px dashed rgba(var(--callout-color), 0.4);
+	border-top: 1px dashed color-mix(in srgb, var(--callout-color) 40%, transparent);
 }
 .aura-callouts.aura-callouts-sleek .callout-fold {
 	padding-right: 0px;
@@ -54,7 +54,7 @@
 	--callout-title-padding: var(--size-4-2);
 }
 .aura-callouts.aura-callouts-sleek .callout.is-collapsible {
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	border-width: 1px;
 	border-radius: var(--callout-radius);
 	background-color: rgba(var(--cpt-mantle), 0.4);
@@ -69,7 +69,7 @@
 .aura-callouts.aura-callouts-sleek
 	.callout.is-collapsible.is-collapsed
 	.callout-title {
-	background-color: rgba(var(--callout-color), 0.1);
+	background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
 	padding: var(--callout-title-padding);
 	cursor: pointer;
 }
@@ -84,9 +84,9 @@
 .aura-callouts.aura-callouts-sleek
 	.callout.is-collapsible:not(.is-collapsed)
 	.callout-title {
-	background-color: rgba(var(--callout-color), 0.1);
+	background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
 	padding: var(--callout-title-padding);
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	cursor: pointer;
 }
 .aura-callouts.aura-callouts-sleek
@@ -94,7 +94,7 @@
 	.callout-content {
 	padding: var(--callout-title-padding) var(--callout-title-padding) 0
 		calc(var(--callout-title-padding) * 1.5);
-	border-top: 1px dashed rgba(var(--callout-color), 0.4);
+	border-top: 1px dashed color-mix(in srgb, var(--callout-color) 40%, transparent);
 }
 .aura-callouts.aura-callouts-sleek .callout:not(.is-collapsible) {
 	padding: 0px;
@@ -102,9 +102,9 @@
 .aura-callouts.aura-callouts-sleek
 	.callout:not(.is-collapsible)
 	.callout-title {
-	background-color: rgba(var(--callout-color), 0.1);
+	background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
 	padding: var(--callout-title-padding);
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 }
 .aura-callouts.aura-callouts-sleek .callout .list-collapse-indicator {
 	margin-left: -35px;
@@ -132,7 +132,7 @@
 	font-weight: bold;
 }
 .aura-callouts.aura-callouts-block .callout:not(.is-collapsible) {
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	border-width: 1px;
 	border-radius: var(--callout-radius);
 	background-color: rgba(var(--cpt-mantle), 0.4);
@@ -148,7 +148,7 @@
 	--callout-title-padding: var(--size-4-2);
 }
 .aura-callouts.aura-callouts-block .callout.is-collapsible {
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	border-width: 1px;
 	border-radius: var(--callout-radius);
 	background-color: rgba(var(--cpt-mantle), 0.4);
@@ -178,7 +178,7 @@
 	.callout.is-collapsible:not(.is-collapsed)
 	.callout-title {
 	padding: var(--callout-title-padding);
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 	cursor: pointer;
 }
 .aura-callouts.aura-callouts-block
@@ -194,7 +194,7 @@
 	.callout:not(.is-collapsible)
 	.callout-title {
 	padding: var(--callout-title-padding);
-	border-color: rgba(var(--callout-color), 0.4);
+	border-color: color-mix(in srgb, var(--callout-color) 40%, transparent);
 }
 .aura-callouts.aura-callouts-block .callout .list-collapse-indicator {
 	margin-left: -35px;

--- a/src/features/origin-layout.scss
+++ b/src/features/origin-layout.scss
@@ -416,14 +416,14 @@ the colorful border interferes with the tab look. */
 .aura-origin-layout .callout {
 	border: none;
 	background-color: var(--background-secondary);
-	border-left: 4px solid rgb(var(--callout-color));
+	border-left: 4px solid var(--callout-color);
 }
 .aura-origin-layout .callout-title-inner {
 	font-weight: bold;
 	margin-left: 0.4em;
 }
 .aura-origin-layout .callout-title {
-	background-color: rgba(var(--callout-color), 0.14);
+	background-color: color-mix(in srgb, var(--callout-color) 14%, transparent);
 }
 
 /* ----- ***** Code and Code Blocks ***** ----- */


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
